### PR TITLE
add show_anc_pops option to plot_model

### DIFF
--- a/spaceprime/demography.py
+++ b/spaceprime/demography.py
@@ -421,5 +421,8 @@ class spDemography(msprime.Demography):
                             rate=migration_rate,
                         )
 
+        # store anc_ids for use in plot_model; None when there's a single ancestral pop
+        self.anc_ids = anc_id if anc_id is not None else None
+
         # sort the events to make sure everything runs in order
         self.sort_events()

--- a/spaceprime/plot.py
+++ b/spaceprime/plot.py
@@ -84,6 +84,7 @@ def plot_model(
     cmap: str = "viridis",
     legend: bool = True,
     tiles: str = "CartoDB positron",
+    show_anc_pops: bool = False,
 ):
     """
     Plots the demes and migration rates for a given timestep as an interactive map.
@@ -102,6 +103,10 @@ def plot_model(
         Whether to show the color legend. Defaults to True.
     tiles : str, optional
         The basemap tiles to use. Defaults to "CartoDB positron".
+    show_anc_pops : bool, optional
+        Whether to color demes by their ancestral population assignment instead of deme
+        size. Requires that `add_ancestral_populations()` was called with an `anc_id`
+        array. Defaults to False.
 
     Returns
     -------
@@ -113,6 +118,8 @@ def plot_model(
     raster = rasterio.open("path/to/raster.tif")
     # Plot the model at timestep 1
     plot_model(demo, raster, 1)
+    # Color demes by ancestral population assignment
+    plot_model(demo, raster, 1, show_anc_pops=True)
 
     Notes
     -----
@@ -124,6 +131,14 @@ def plot_model(
 
     # check if the number of timesteps is valid
     validate_timestep(timestep, demo)
+
+    if show_anc_pops and (
+        not hasattr(demo, "anc_ids") or demo.anc_ids is None
+    ):
+        raise ValueError(
+            "show_anc_pops=True requires ancestral population IDs on the model. "
+            "Call add_ancestral_populations() with the anc_id parameter first."
+        )
 
     # Get the demes matrix for the specified timestep
     demes_matrix = demo.demes[timestep]
@@ -154,21 +169,39 @@ def plot_model(
     # Add the deme index to the GeoDataFrame
     gdf["deme_index"] = gdf.index.to_list()
 
-    # Plot the GeoDataFrames
-    plot = gdf.explore(
-        column="deme_size",
-        tooltip=[
-            "deme_size",
-            "mig_north",
-            "mig_east",
-            "mig_south",
-            "mig_west",
-            "deme_index",
-        ],
-        cmap=cmap,
-        legend=legend,
-        tiles=tiles,
-    )
+    if show_anc_pops:
+        gdf["anc_pop"] = np.asarray(demo.anc_ids)[mask].astype(int)
+        plot = gdf.explore(
+            column="anc_pop",
+            tooltip=[
+                "anc_pop",
+                "deme_size",
+                "mig_north",
+                "mig_east",
+                "mig_south",
+                "mig_west",
+                "deme_index",
+            ],
+            cmap=cmap,
+            legend=legend,
+            tiles=tiles,
+            categorical=True,
+        )
+    else:
+        plot = gdf.explore(
+            column="deme_size",
+            tooltip=[
+                "deme_size",
+                "mig_north",
+                "mig_east",
+                "mig_south",
+                "mig_west",
+                "deme_index",
+            ],
+            cmap=cmap,
+            legend=legend,
+            tiles=tiles,
+        )
 
     return plot
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -70,6 +70,13 @@ def raster():
     return rasterio.open("tests/data/demes_raster.tif")
 
 
+@pytest.fixture
+def demo_with_anc_ids(demo):
+    # top row belongs to ANC_1, bottom row to ANC_2
+    demo.anc_ids = np.array([[1, 1], [2, 2]])
+    return demo
+
+
 # get_outgoing_migration_rates
 def test_get_outgoing_migration_rates_values(demes, mig_mat):
     outgoing_migration_rates = plot.get_outgoing_migration_rates(demes, mig_mat)
@@ -113,6 +120,25 @@ def test_plot_model_returns_plot(demo, raster) -> None:
 
     # Test 1: Check if a folium.Map object is returned
     assert isinstance(p, folium.Map)
+
+
+def test_plot_model_show_anc_pops_returns_plot(demo_with_anc_ids, raster) -> None:
+    """Test that show_anc_pops=True returns a folium.Map colored by ancestral population"""
+    p = plot.plot_model(demo_with_anc_ids, raster, 0, show_anc_pops=True)
+    assert isinstance(p, folium.Map)
+
+
+def test_plot_model_show_anc_pops_no_anc_ids(demo, raster) -> None:
+    """Test that show_anc_pops=True raises ValueError when anc_ids is not set"""
+    with pytest.raises(ValueError, match="show_anc_pops=True requires"):
+        plot.plot_model(demo, raster, 0, show_anc_pops=True)
+
+
+def test_plot_model_show_anc_pops_anc_ids_none(demo, raster) -> None:
+    """Test that show_anc_pops=True raises ValueError when anc_ids is None"""
+    demo.anc_ids = None
+    with pytest.raises(ValueError, match="show_anc_pops=True requires"):
+        plot.plot_model(demo, raster, 0, show_anc_pops=True)
 
 
 # plot_landscape


### PR DESCRIPTION
Closes #27.

## Summary

- Stores `anc_ids` on `spDemography` when `add_ancestral_populations()` is called with an `anc_id` array (set to `None` for single-ancestor models)
- Adds `show_anc_pops: bool = False` parameter to `plot_model`; when `True`, demes are colored categorically by ancestral population assignment and `anc_pop` is added to the tooltip
- Raises a clear `ValueError` if `show_anc_pops=True` but `anc_ids` was not set (i.e. `add_ancestral_populations` was not called with `anc_id`)

## Test plan

- [ ] `test_plot_model_show_anc_pops_returns_plot` — asserts a `folium.Map` is returned
- [ ] `test_plot_model_show_anc_pops_no_anc_ids` — asserts `ValueError` when `anc_ids` not set
- [ ] `test_plot_model_show_anc_pops_anc_ids_none` — asserts `ValueError` when `anc_ids` is `None`
- [ ] All 83 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)