### PR TITLE
Add --map_sample_num CLI arg for diversity map sampling

### DIFF
--- a/spaceprime/cli.py
+++ b/spaceprime/cli.py
@@ -145,7 +145,7 @@ def get_coal_times(tseq, raster, num_anc_pops, sample_num=2, ploidy=2):
 
     coal_1d = np.array(coal_list)[:-num_anc_pops]
 
-    coal_array = np.reshape(coal_1d, newshape=raster.shape)
+    coal_array = np.reshape(coal_1d, raster.shape)
 
     return coal_array
 

--- a/spaceprime/cli.py
+++ b/spaceprime/cli.py
@@ -321,7 +321,7 @@ def run_simulation(combo, args):
         else:
             min_num_inds = 2
 
-        samples = get_map_dict(d, min_num_inds=min_num_inds)
+        samples = get_map_dict(d, min_num_inds=min_num_inds, sample_num=args.map_sample_num)
     else:
         samples = sample_dicts[0]
 
@@ -434,10 +434,10 @@ def run_simulation(combo, args):
                     r,
                     len(set(anc_pop_id)),
                     ploidy=args.ploidy,
-                    sample_num=2,
+                    sample_num=args.map_sample_num,
                 )
             else:
-                coal_array = get_coal_times(ts, r, 1, ploidy=args.ploidy, sample_num=2)
+                coal_array = get_coal_times(ts, r, 1, ploidy=args.ploidy, sample_num=args.map_sample_num)
 
             utilities.create_raster(
                 coal_array,
@@ -573,7 +573,7 @@ def main():
         nargs="+",
         type=sci_notation_int,
         default=[1000],
-        help="Maximum size of local demes. Accepts a single int or a pair of ints. Default is [1000].",
+        help="Maximum size of local demes. Accepts a single int or a pair of ints [min, max]. When --num_param_combos > 1, a pair is treated as a range and a random value is drawn uniformly from it for each parameter combination. Default is [1000].",
     )
     demography_parser.add_argument(
         "-th",
@@ -581,7 +581,7 @@ def main():
         nargs="+",
         type=float,
         default=None,
-        help="Threshold value for a thresholded transformation. Accepts a single float or a pair of floats. Default is None.",
+        help="Threshold value for a thresholded transformation. Accepts a single float or a pair of floats [min, max]. When --num_param_combos > 1, a pair is treated as a range and a random value is drawn uniformly from it for each parameter combination. Default is None.",
     )
     demography_parser.add_argument(
         "-ip",
@@ -589,7 +589,7 @@ def main():
         nargs="+",
         type=float,
         default=[0.5],
-        help="Inflection point value for a sigmoid transformation. Accepts a single int or a pair of ints. Default is [0.5].",
+        help="Inflection point value for a sigmoid transformation. Accepts a single float or a pair of floats [min, max]. When --num_param_combos > 1, a pair is treated as a range and a random value is drawn uniformly from it for each parameter combination. Default is [0.5].",
     )
     demography_parser.add_argument(
         "-s",
@@ -597,7 +597,7 @@ def main():
         nargs="+",
         type=float,
         default=[0.05],
-        help="Slope value for a sigmoid transformation. Accepts a single int or a pair of ints. Default is [0.05].",
+        help="Slope value for a sigmoid transformation. Accepts a single float or a pair of floats [min, max]. When --num_param_combos > 1, a pair is treated as a range and a random value is drawn uniformly from it for each parameter combination. Default is [0.05].",
     )
     demography_parser.add_argument(
         "-m",
@@ -605,7 +605,7 @@ def main():
         nargs="+",
         type=float,
         default=None,
-        help="Migration rate between demes. Accepts a single int or a pair of ints. Default is None.",
+        help="Migration rate between demes. Accepts a single float or a pair of floats [min, max]. When --num_param_combos > 1, a pair is treated as a range and a random value is drawn uniformly from it for each parameter combination. Default is None.",
     )
     demography_parser.add_argument(
         "-sc",
@@ -634,7 +634,7 @@ def main():
         nargs="+",
         type=lambda x: [int(float(i)) for i in x.split(",")],
         default=None,
-        help="List of sizes for ancestral populations. Accepts a list of single values or a list of pairs of values. Default is None.",
+        help="List of sizes for ancestral populations. Accepts a list of single values or a list of pairs of values [min, max]. When --num_param_combos > 1, each pair is treated as a range and a random value is drawn uniformly from it for each parameter combination. Default is None.",
     )
     demography_parser.add_argument(
         "-mt",
@@ -642,7 +642,7 @@ def main():
         nargs="+",
         type=sci_notation_int,
         default=None,
-        help="Time that demes merge into one or more ancestral populations. Measured in generations. Accepts a single int or a pair of ints. Default is None.",
+        help="Time that demes merge into one or more ancestral populations. Measured in generations. Accepts a single int or a pair of ints [min, max]. When --num_param_combos > 1, a pair is treated as a range and a random int is drawn uniformly from it for each parameter combination. Default is None.",
     )
     demography_parser.add_argument(
         "-amt",
@@ -650,7 +650,7 @@ def main():
         nargs="+",
         type=sci_notation_int,
         default=None,
-        help="Merge time for ancestral populations. Measured in generations. Accepts a single int or a pair of ints. Default is None.",
+        help="Merge time for ancestral populations. Measured in generations. Accepts a single int or a pair of ints [min, max]. When --num_param_combos > 1, a pair is treated as a range and a random int is drawn uniformly from it for each parameter combination. Default is None.",
     )
     demography_parser.add_argument(
         "-ams",
@@ -658,7 +658,7 @@ def main():
         nargs="+",
         type=sci_notation_int,
         default=None,
-        help="Merge size for ancestral populations. Accepts a single int or a pair of ints. Default is None.",
+        help="Merge size for ancestral populations. Accepts a single int or a pair of ints [min, max]. When --num_param_combos > 1, a pair is treated as a range and a random int is drawn uniformly from it for each parameter combination. Default is None.",
     )
     demography_parser.add_argument(
         "-amr",
@@ -666,7 +666,7 @@ def main():
         nargs="+",
         type=float,
         default=None,
-        help="Migration rate between ancestral populations. Accepts a single int or a pair of ints. Default is None.",
+        help="Migration rate between ancestral populations. Accepts a single float or a pair of floats [min, max]. When --num_param_combos > 1, a pair is treated as a range and a random value is drawn uniformly from it for each parameter combination. Default is None.",
     )
     # Simulation Setup
     simulation_parser = parser.add_argument_group("Simulation Setup")
@@ -683,7 +683,7 @@ def main():
         nargs="+",
         type=float,
         default=[1e-8],
-        help="Mutation rate per generation per base pair. Accepts a single float or a pair of floats. Default is [1e-8].",
+        help="Mutation rate per generation per base pair. Accepts a single float or a pair of floats [min, max]. When --num_param_combos > 1, a pair is treated as a range and a random value is drawn uniformly from it for each parameter combination. Default is [1e-8].",
     )
     simulation_parser.add_argument(
         "-rr",
@@ -691,7 +691,7 @@ def main():
         nargs="+",
         type=float,
         default=[0],
-        help="Recombination rate per generation per base pair. Accepts a single float or a pair of floats. Default is [0].",
+        help="Recombination rate per generation per base pair. Accepts a single float or a pair of floats [min, max]. When --num_param_combos > 1, a pair is treated as a range and a random value is drawn uniformly from it for each parameter combination. Default is [0].",
     )
     simulation_parser.add_argument(
         "-pl",
@@ -705,7 +705,7 @@ def main():
         "--num_param_combos",
         type=int,
         default=1,
-        help="Number of parameter combinations to simulate. Default is 1.",
+        help="Number of parameter combinations to simulate. When > 1, any argument that accepts a pair of values treats that pair as a [min, max] range and draws a random value from it for each combination. Default is 1.",
     )
     simulation_parser.add_argument(
         "-ncs",
@@ -781,6 +781,14 @@ def main():
         type=bool,
         default=False,
         help="Simulate the genetic diversity for each deme across entire landscape and output a GeoTiff. Overrides out_type. Default is False.",
+    )
+
+    parser.add_argument(
+        "-msn",
+        "--map_sample_num",
+        type=int,
+        default=2,
+        help="Number of individuals to sample per deme when generating a diversity map (--map). Higher values give more accurate diversity estimates at the cost of simulation time. Default is 2.",
     )
 
     parser.add_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,104 @@
 #!/usr/bin/env python
 
 """Tests for `cli` module."""
+import numpy as np
 import pytest
-from spaceprime.cli import sci_notation_int
+
+from spaceprime import demography, simulation
+from spaceprime.cli import get_coal_times, get_map_dict, sci_notation_int
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def simple_demo():
+    """2x2 spDemography with a single ancestral population."""
+    d = np.array([[1000.0, 500.0], [200.0, 300.0]])
+    demo = demography.spDemography()
+    demo.stepping_stone_2d(d, rate=0.01)
+    demo.add_ancestral_populations(anc_sizes=[5000], merge_time=500)
+    return demo
+
+
+@pytest.fixture
+def raster_2x2(tmp_path):
+    """Minimal 2x2 rasterio dataset matching the simple_demo grid."""
+    import rasterio
+    from rasterio.transform import from_bounds
+
+    path = tmp_path / "raster.tif"
+    transform = from_bounds(0, 0, 1, 1, 2, 2)
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=2,
+        width=2,
+        count=1,
+        dtype="float32",
+        crs="EPSG:4326",
+        transform=transform,
+    ) as dst:
+        dst.write(np.ones((1, 2, 2), dtype="float32"))
+    return rasterio.open(path)
+
+
+# ---------------------------------------------------------------------------
+# get_map_dict
+# ---------------------------------------------------------------------------
+
+
+class TestGetMapDict:
+    def test_default_sample_num(self, simple_demo):
+        """Default sample_num=2 is reflected in every deme's value."""
+        result = get_map_dict(simple_demo)
+        assert all(v == 2 for v in result.values())
+
+    def test_custom_sample_num(self, simple_demo):
+        """sample_num is passed through to each deme's value."""
+        result = get_map_dict(simple_demo, sample_num=5)
+        assert all(v == 5 for v in result.values())
+
+    def test_excludes_small_demes(self, simple_demo):
+        """Demes smaller than min_num_inds are excluded."""
+        result_strict = get_map_dict(simple_demo, min_num_inds=400)
+        result_loose = get_map_dict(simple_demo, min_num_inds=2)
+        assert len(result_strict) < len(result_loose)
+
+
+# ---------------------------------------------------------------------------
+# get_coal_times
+# ---------------------------------------------------------------------------
+
+
+class TestGetCoalTimes:
+    def test_output_shape_matches_raster(self, simple_demo, raster_2x2):
+        """get_coal_times returns an array shaped like the raster."""
+        ts = simulation.sim_ancestry(
+            samples=get_map_dict(simple_demo, sample_num=2),
+            demography=simple_demo,
+            sequence_length=1000,
+            random_seed=42,
+        )
+        ts = simulation.sim_mutations(ts, rate=1e-8, random_seed=42)
+        result = get_coal_times(ts, raster_2x2, num_anc_pops=1, sample_num=2)
+        assert result.shape == (2, 2)
+
+    def test_custom_sample_num_changes_which_pops_are_scored(self, simple_demo, raster_2x2):
+        """With sample_num=5, populations sampled at 2 get -1 (no match)."""
+        ts_2 = simulation.sim_ancestry(
+            samples=get_map_dict(simple_demo, sample_num=2),
+            demography=simple_demo,
+            sequence_length=1000,
+            random_seed=42,
+        )
+        ts_2 = simulation.sim_mutations(ts_2, rate=1e-8, random_seed=42)
+        result = get_coal_times(ts_2, raster_2x2, num_anc_pops=1, sample_num=5)
+        # All demes were sampled at 2, not 5, so none should be scored
+        assert np.all(result == -1)
 
 
 def test_sci_notation_int_plain_int():


### PR DESCRIPTION
## Summary

- Adds `-msn`/`--map_sample_num` argument (default: `2`) to control the number of individuals sampled per deme when generating a spatial diversity map with `--map`
- Replaces three hardcoded `sample_num=2` values in `get_map_dict` and `get_coal_times` call sites with the new argument
- Higher values give more accurate per-deme diversity estimates at the cost of simulation time

Closes #16

## Test plan

- [x] Run with `--map` and default `--map_sample_num 2` — output should be identical to previous behavior
- [x] Run with `--map --map_sample_num 5` — verify the simulation runs and the output GeoTiff is produced without error
- [x] Verify `spaceprime --help` shows the new argument with its description

🤖 Generated with [Claude Code](https://claude.com/claude-code)