### PR TITLE
Fix CLI crashes on normal invocations

### DIFF
--- a/docs/cli.qmd
+++ b/docs/cli.qmd
@@ -232,7 +232,7 @@ When `--params` is provided, all command-line arguments are ignored in favour of
 | `--threshold` | `-th` | float | `null` | Habitat value below which demes are set to zero (threshold transformation). Single value or `[min, max]`. |
 | `--inflection_point` | `-ip` | float | `0.5` | Inflection point of the sigmoid transformation. Single value or `[min, max]`. |
 | `--slope` | `-s` | float | `0.05` | Slope of the sigmoid transformation. Single value or `[min, max]`. |
-| `--mig_rate` | `-m` | float | `null` | Global migration rate between adjacent demes. Single value or `[min, max]`. |
+| `--mig_rate` | `-m` | float | `1e-8` | Global migration rate between adjacent demes. Single value or `[min, max]`. |
 | `--scale` | `-sc` | bool | `true` | Scale migration by donor/recipient deme size: `m = (N_donor / N_recipient) * m_global`. |
 | `--anc_pop_id` | `-a` | str/list | `null` | Ancestral population assignments. Path to a CSV with column `anc_pop_id`, or a comma-separated list. Length must equal the number of sampling coordinates. |
 | `--timesteps` | `-ts` | int | `1` | Generations between demographic events (for multi-time-slice rasters). |

--- a/spaceprime/cli.py
+++ b/spaceprime/cli.py
@@ -72,6 +72,7 @@ def read_coords(file_path):
 # read in individual IDs if a path is provided, otherwise use the list
 # also perform a series of checks
 def read_individuals(args, coords):
+    individuals = None
     if args.individuals is not None:
         if isinstance(args.individuals, str):
             if not os.path.exists(args.individuals):
@@ -187,20 +188,19 @@ def setup_demography(
         anc_pop_mat = None
 
     # create demography
-    d = demography.stepping_stone_2d(
-        d=demes, rate=mig_rate, scale=scale, timesteps=timesteps
-    )
+    d = demography.spDemography()
+    d.stepping_stone_2d(d=demes, rate=mig_rate, scale=scale, timesteps=timesteps)
 
     # add ancestral populations
-    d = demography.add_ancestral_populations(
-        model=d,
-        anc_sizes=anc_sizes,
-        merge_time=merge_time,
-        anc_id=anc_pop_mat,
-        anc_merge_times=anc_merge_time,
-        anc_merge_sizes=anc_merge_size,
-        migration_rate=anc_mig_rate,
-    )
+    if anc_sizes is not None and merge_time is not None:
+        d.add_ancestral_populations(
+            anc_sizes=anc_sizes,
+            merge_time=merge_time,
+            anc_id=anc_pop_mat,
+            anc_merge_times=anc_merge_time,
+            anc_merge_sizes=anc_merge_size,
+            migration_rate=anc_mig_rate,
+        )
 
     return d
 
@@ -539,8 +539,8 @@ def run_simulation(combo, args):
     logger.info("Simulation complete for demo_id=%s", demo_id)
 
 
-def main():
-    """Console script for spaceprime."""
+def build_parser():
+    """Return the CLI argument parser."""
     parser = argparse.ArgumentParser()
     # global arguments
     parser.add_argument(
@@ -622,8 +622,8 @@ def main():
         "--mig_rate",
         nargs="+",
         type=float,
-        default=None,
-        help="Migration rate between demes. Accepts a single float or a pair of floats [min, max]. When --num_param_combos > 1, a pair is treated as a range and a random value is drawn uniformly from it for each parameter combination. Default is None.",
+        default=[1e-8],
+        help="Migration rate between demes. Accepts a single float or a pair of floats [min, max]. When --num_param_combos > 1, a pair is treated as a range and a random value is drawn uniformly from it for each parameter combination. Default is 1e-8.",
     )
     demography_parser.add_argument(
         "-sc",
@@ -650,7 +650,7 @@ def main():
         "-as",
         "--anc_sizes",
         nargs="+",
-        type=lambda x: [int(float(i)) for i in x.split(",")],
+        type=lambda x: [int(float(i)) for i in x.split(",")] if "," in x else int(float(x)),
         default=None,
         help="List of sizes for ancestral populations. Accepts a list of single values or a list of pairs of values [min, max]. When --num_param_combos > 1, each pair is treated as a range and a random value is drawn uniformly from it for each parameter combination. Default is None.",
     )
@@ -846,6 +846,12 @@ def main():
         help="Number of CPUs to use for parallel processing. Default is 1.",
     )
 
+    return parser
+
+
+def main():
+    """Console script for spaceprime."""
+    parser = build_parser()
     args = parser.parse_args()
 
     # Check if params YAML file exists. If so, update command line arguments with parameters from YAML file
@@ -875,7 +881,7 @@ def main():
     args.anc_pop_id = check_list_argument(args.anc_pop_id)
     args.anc_sizes = check_list_argument(args.anc_sizes)
     # make sure anc_sizes is a list of single value or a list of lists with two values in each element
-    if args.anc_sizes[0] is not None:
+    if args.anc_sizes is not None and args.anc_sizes[0] is not None:
         if isinstance(args.anc_sizes[0], list):
             args.anc_sizes = [list(map(int, size)) for size in args.anc_sizes]
             for size in args.anc_sizes:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,22 @@
 #!/usr/bin/env python
 
 """Tests for `cli` module."""
+import argparse
+
 import numpy as np
 import pytest
+from geopandas import GeoDataFrame
+from shapely.geometry import Point
 
 from spaceprime import demography, simulation
-from spaceprime.cli import get_coal_times, get_map_dict, sci_notation_int
+from spaceprime.cli import (
+    build_parser,
+    get_coal_times,
+    get_map_dict,
+    read_individuals,
+    sci_notation_int,
+    setup_demography,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -119,3 +130,134 @@ def test_sci_notation_int_scientific_notation_small_exponent():
 def test_sci_notation_int_raises_on_non_numeric():
     with pytest.raises((ValueError, TypeError)):
         sci_notation_int("abc")
+
+
+# ---------------------------------------------------------------------------
+# read_individuals
+# ---------------------------------------------------------------------------
+
+
+class TestReadIndividuals:
+    def test_returns_none_when_individuals_omitted(self):
+        """No UnboundLocalError when --individuals is not supplied."""
+        args = argparse.Namespace(individuals=None)
+        assert read_individuals(args, coords=[]) is None
+
+    def test_returns_list_when_given_list(self):
+        """Inline list of IDs is passed through unchanged."""
+        ids = ["ind_1", "ind_2"]
+        args = argparse.Namespace(individuals=ids)
+        coords = [None, None]
+        assert read_individuals(args, coords) == ids
+
+    def test_raises_when_length_mismatch(self):
+        """Mismatched individuals / coords length raises ValueError."""
+        args = argparse.Namespace(individuals=["ind_1", "ind_2", "ind_3"])
+        coords = [None, None]
+        with pytest.raises(ValueError, match="Number of individuals"):
+            read_individuals(args, coords)
+
+
+# ---------------------------------------------------------------------------
+# Argument parser defaults and type lambdas
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParser:
+    def test_mig_rate_default_is_1e8(self):
+        """--mig_rate defaults to [1e-8], not None."""
+        args = build_parser().parse_args([])
+        assert args.mig_rate == [1e-8]
+
+    def test_anc_sizes_single_value_is_scalar_int(self):
+        """Single --anc_sizes token parses as a plain int, not a list."""
+        args = build_parser().parse_args(["-as", "5000"])
+        assert args.anc_sizes == [5000]
+        assert isinstance(args.anc_sizes[0], int)
+
+    def test_anc_sizes_comma_pair_is_list(self):
+        """Comma-separated --anc_sizes pair parses as a list of two ints."""
+        args = build_parser().parse_args(["-as", "5000,8000"])
+        assert args.anc_sizes == [[5000, 8000]]
+
+    def test_anc_sizes_multiple_singles(self):
+        """Multiple space-separated --anc_sizes values parse as a flat int list."""
+        args = build_parser().parse_args(["-as", "5000", "6000"])
+        assert args.anc_sizes == [5000, 6000]
+        assert all(isinstance(v, int) for v in args.anc_sizes)
+
+    def test_anc_sizes_defaults_to_none(self):
+        """--anc_sizes defaults to None when omitted."""
+        args = build_parser().parse_args([])
+        assert args.anc_sizes is None
+
+
+# ---------------------------------------------------------------------------
+# setup_demography
+# ---------------------------------------------------------------------------
+
+
+class TestSetupDemography:
+    def test_returns_spdemography_with_default_mig_rate(self, raster):
+        """setup_demography succeeds with mig_rate=0.0 and no ancestral pops."""
+        result = setup_demography(
+            raster=raster,
+            coords=None,
+            max_local_size=1000,
+            threshold=None,
+            inflection_point=0.5,
+            slope=0.05,
+            mig_rate=0.0,
+            scale=True,
+            anc_pop_id=None,
+            timesteps=1,
+            anc_sizes=None,
+            merge_time=None,
+            anc_merge_time=None,
+            anc_merge_size=None,
+            anc_mig_rate=None,
+        )
+        assert isinstance(result, demography.spDemography)
+        assert len(result.populations) > 0
+
+    def test_anc_sizes_none_skips_ancestral_populations(self, raster):
+        """No ancestral populations are added when anc_sizes is None."""
+        result = setup_demography(
+            raster=raster,
+            coords=None,
+            max_local_size=1000,
+            threshold=None,
+            inflection_point=0.5,
+            slope=0.05,
+            mig_rate=0.0,
+            scale=True,
+            anc_pop_id=None,
+            timesteps=1,
+            anc_sizes=None,
+            merge_time=None,
+            anc_merge_time=None,
+            anc_merge_size=None,
+            anc_mig_rate=None,
+        )
+        assert not any("ANC" in p.name for p in result.populations)
+
+    def test_anc_sizes_provided_adds_ancestral_population(self, raster):
+        """Ancestral population is added when anc_sizes and merge_time are set."""
+        result = setup_demography(
+            raster=raster,
+            coords=None,
+            max_local_size=1000,
+            threshold=None,
+            inflection_point=0.5,
+            slope=0.05,
+            mig_rate=0.0,
+            scale=True,
+            anc_pop_id=None,
+            timesteps=1,
+            anc_sizes=[5000],
+            merge_time=500,
+            anc_merge_time=None,
+            anc_merge_size=None,
+            anc_mig_rate=None,
+        )
+        assert any("ANC" in p.name for p in result.populations)


### PR DESCRIPTION
## Summary

- Fixed five bugs that prevented any CLI invocation from completing
- Added 11 regression tests covering all fixed code paths
- Updated `--mig_rate` default in `docs/cli.qmd`

## Bugs fixed

| Location | Bug |
|---|---|
| `read_individuals` | `UnboundLocalError` when `--individuals` is omitted — variable only assigned inside the `is not None` branch |
| `main()` anc_sizes processing | `TypeError: 'NoneType' object is not subscriptable` from `args.anc_sizes[0]` when `--anc_sizes` is omitted |
| `--anc_sizes` type lambda | Single values were wrapped in a list (e.g. `5000` → `[5000]`) instead of parsed as a scalar, breaking the `isinstance(anc_sizes[0], list)` range-detection downstream |
| `setup_demography` | `stepping_stone_2d` and `add_ancestral_populations` called as module-level functions — both are `spDemography` instance methods. Fixed to `d = demography.spDemography()` / `d.stepping_stone_2d(...)` pattern; `add_ancestral_populations` is now guarded so it only runs when both `anc_sizes` and `merge_time` are provided |
| `--mig_rate` | Defaulted to `None`, causing `TypeError: Invalid rate input. Expected float.` in `calc_migration_matrix`; default is now `1e-8` |

## Test plan

- [ ] `pixi run -e dev test` passes (105 tests)
- [ ] New `TestReadIndividuals`, `TestBuildParser`, and `TestSetupDemography` classes cover the fixed paths
- [ ] CLI runs to tree-sequence output with `spaceprime -r <raster> -co <coords> -as 5000 -mt 500`

🤖 Generated with [Claude Code](https://claude.com/claude-code)